### PR TITLE
Let UAssetEditorSubsystem know editor was closed

### DIFF
--- a/Source/AssetEditorTemplateEditor/Private/AssetEditor/SimpleAssetEditorToolkit.cpp
+++ b/Source/AssetEditorTemplateEditor/Private/AssetEditor/SimpleAssetEditorToolkit.cpp
@@ -196,4 +196,17 @@ TSharedRef<SDockTab> FSimpleAssetEditorToolkit::SpawnTab_Viewport(const FSpawnTa
 	return SpawnedTab;
 }
 
+
+void FSimpleAssetEditorToolkit::OnClose()
+{
+	SimpleAsset = nullptr;
+
+	// We're no longer editing this object, so let the editor know
+	if (GEditor)
+	{
+		GEditor->GetEditorSubsystem<UAssetEditorSubsystem>()->NotifyEditorClosed(this);
+	}
+
+}
+
 #undef LOCTEXT_NAMESPACE

--- a/Source/AssetEditorTemplateEditor/Public/AssetEditor/SimpleAssetEditorToolkit.h
+++ b/Source/AssetEditorTemplateEditor/Public/AssetEditor/SimpleAssetEditorToolkit.h
@@ -48,4 +48,7 @@ private:
 	USimpleAsset* SimpleAsset;
 	TSharedPtr<FSimpleAssetPreviewScene> PreviewScene;
 	TSharedPtr<SSimpleAssetViewport> PreviewViewportWidget;
+protected:
+	void OnClose() override;
+
 };


### PR DESCRIPTION
fixes problems like crashes on close(5.2), reopening the asset editor on every restart of the UEeditor and not opening the asset editor after closing it once (because it tries to bring the closed asset editor into focus)