### PR TITLE
Fixed Crash On Close for Unreal Version 5.2

### DIFF
--- a/Source/AssetEditorTemplateEditor/Private/AssetEditor/SimpleAssetEditorToolkit.cpp
+++ b/Source/AssetEditorTemplateEditor/Private/AssetEditor/SimpleAssetEditorToolkit.cpp
@@ -201,12 +201,15 @@ void FSimpleAssetEditorToolkit::OnClose()
 {
 	SimpleAsset = nullptr;
 
-	// We're no longer editing this object, so let the editor know
-	if (GEditor)
+	if(PreviewScene.IsValid())
 	{
-		GEditor->GetEditorSubsystem<UAssetEditorSubsystem>()->NotifyEditorClosed(this);
+		PreviewScene.Reset();
 	}
-
+		
+	if(PreviewViewportWidget.IsValid())
+	{
+		PreviewViewportWidget.Reset();
+	}
 }
 
 #undef LOCTEXT_NAMESPACE


### PR DESCRIPTION
Decremented the reference counters to  PreviewScene and PreviewViewportWidget.

The base destructor of SimpleAssetEditorToolkit then gets successfully called. Which automatically lets the editor know the window gets closed.