### PR TITLE
Referencer Name Added to fix compiling issues for UE5.5

### DIFF
--- a/Source/AssetEditorTemplateEditor/Private/AssetEditor/SimpleAssetViewport.cpp
+++ b/Source/AssetEditorTemplateEditor/Private/AssetEditor/SimpleAssetViewport.cpp
@@ -25,6 +25,12 @@ SSimpleAssetViewport::~SSimpleAssetViewport()
 	}
 }
 
+FString SSimpleAssetViewport::GetReferencerName() const
+{
+	return TEXT("SSimpleAssetViewport");
+
+}
+
 TSharedRef<class SEditorViewport> SSimpleAssetViewport::GetViewportWidget()
 {
 	return SharedThis(this);

--- a/Source/AssetEditorTemplateEditor/Public/AssetEditor/SimpleAssetViewport.h
+++ b/Source/AssetEditorTemplateEditor/Public/AssetEditor/SimpleAssetViewport.h
@@ -45,6 +45,7 @@ public:
 
 	virtual void AddReferencedObjects(FReferenceCollector& Collector) override {}
 
+	virtual FString GetReferencerName() const override;
 	virtual TSharedRef<class SEditorViewport> GetViewportWidget() override;
 	virtual TSharedPtr<FExtender> GetExtenders() const override;
 	virtual void OnFloatingButtonClicked() override;


### PR DESCRIPTION
Project doesn't compile properly on Unreal Engine 5.5, this adds in the missing functions to SimpleAssetViewport.h to fix that.